### PR TITLE
Fix Blogs on /Research route on refresh

### DIFF
--- a/app/research/page.js
+++ b/app/research/page.js
@@ -3,23 +3,23 @@ import CallToAction from "@/components/CallToAction";
 import BlogClientList from "@/components/BlogClientList";
 import { fetchBlogs } from "@/services/blogService";
 
+
 import "./ResearchPage.css";
+import AOSWrapper from "@/components/AOSWrapper";
 
 export default async function ResearchPage() {
   const blogs = await fetchBlogs();
-  console.log(blogs);
 
   return (
-    <>
-      <Hero
-        title="Blog & Research"
-        subtitle="Stay Updated with the Latest News, Events, and Insight"
-        backgroundClass="research-hero"
-      />
-
-      <BlogClientList initialBlogs={blogs} />
-
-      <CallToAction />
-    </>
+    <div>
+        <AOSWrapper />
+        <Hero
+          title="Blog & Research"
+          subtitle="Stay Updated with the Latest News, Events, and Insight"
+          backgroundClass="research-hero"
+        />
+        <BlogClientList initialBlogs={blogs} />
+        <CallToAction />
+    </div>
   );
 }


### PR DESCRIPTION
Fixed issue with research page not populating blogs correctly on refresh due to improper original usage of <AOSWrapper /> as <AOSWrapper > ...<AOSWrapper />.