### PR TITLE
Add await to params on research/[blogId] to satisfy nextjs error

### DIFF
--- a/app/research/[blogId]/page.js
+++ b/app/research/[blogId]/page.js
@@ -17,7 +17,7 @@ export async function generateStaticParams() {
 }
 
 export async function generateMetadata({ params }) {
-  const { blogId } = params;
+  const { blogId } = await params;
   const blog = await fetchBlog(blogId);
 
   if (!blog) {
@@ -34,7 +34,7 @@ export async function generateMetadata({ params }) {
 }
 
 export default async function BlogPage({ params }) {
-  const { blogId } =  params;
+  const { blogId } =  await params;
   const blog = await fetchBlog(blogId);
   const content = blog.content?.rendered || "";
   const sanitizedHtml = DOMPurify.sanitize(content);


### PR DESCRIPTION
Satisfy error with params needing to be awaited. Should not affect functionality (research/[blogId] being SSG with ISR) because params is an object, not a promise anyways in this context, and generateStaticParams forces SSG.