### PR TITLE
Add /portfolio redirect to Google Site

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -27,6 +27,11 @@ module.exports = {
         destination: '/',
         permanent: true,
       },
+	  {
+      	source: '/portfolio',
+      	destination: 'https://sites.google.com/projxon.com/projxon-portfolio/home',
+     	 permanent: true,
+      },
     ];
   },
 };


### PR DESCRIPTION
Adds a permanent 301 redirect from /portfolio to the PROJXON Portfolio Google Site. 
Supports the IT request to forward www.projxon.com/portfolio to the existing Google Site.